### PR TITLE
Modification in CalcBlockForDuration Function

### DIFF
--- a/util/time.go
+++ b/util/time.go
@@ -21,10 +21,6 @@ func CalcBlockForDuration(timeoutMs string) (time.Duration, error) {
 			return 0, err
 		}
 		if parsed > 0 {
-			// Limit to 60 seconds
-			if parsed > 60000 {
-				parsed = 60000
-			}
 			blockFor = time.Duration(parsed) * time.Millisecond
 		}
 	}


### PR DESCRIPTION
In the current implementation of the function, the maximum block time is limited to 60 seconds, which is not always suitable for all operations. For example, in scenarios where a large file needs to be downloaded, this time may not be sufficient. Removing this limitation allows for setting longer block durations, making the function more versatile and suitable for a variety of tasks.