### PR TITLE
Added per-user quota admin api

### DIFF
--- a/api/custom/users.go
+++ b/api/custom/users.go
@@ -1,0 +1,74 @@
+package custom
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/t2bot/matrix-media-repo/api/_apimeta"
+	"github.com/t2bot/matrix-media-repo/api/_responses"
+	"github.com/t2bot/matrix-media-repo/database"
+
+	"github.com/t2bot/matrix-media-repo/common/rcontext"
+)
+
+type UserQuotaEntry struct {
+	MaxBytes   int64 `json:"max_bytes"`
+	MaxPending int64 `json:"max_pending"`
+	MaxFiles   int64 `json:"max_files"`
+}
+
+func GetUserQuota(r *http.Request, rctx rcontext.RequestContext, user _apimeta.UserInfo) interface{} {
+	userIds := r.URL.Query()["user_id"]
+
+	db := database.GetInstance().UserStats.Prepare(rctx)
+
+	records, err := db.GetUserQuota(userIds)
+	if err != nil {
+		rctx.Log.Error(err)
+		sentry.CaptureException(err)
+		return _responses.InternalServerError("Failed to get quota for users")
+	}
+
+	parsed := make(map[string]*UserQuotaEntry)
+
+	for _, quota := range records {
+		entry := &UserQuotaEntry{
+			MaxBytes:   quota.UserQuota.MaxBytes,
+			MaxPending: quota.UserQuota.MaxPending,
+			MaxFiles:   quota.UserQuota.MaxFiles,
+		}
+		parsed[quota.UserId] = entry
+	}
+
+	return &_responses.DoNotCacheResponse{Payload: parsed}
+}
+
+func SetUserQuota(r *http.Request, rctx rcontext.RequestContext, user _apimeta.UserInfo) interface{} {
+	decoder := json.NewDecoder(r.Body)
+	params := make(map[string]*UserQuotaEntry)
+	err := decoder.Decode(&params)
+	if err != nil {
+		rctx.Log.Error(err)
+		sentry.CaptureException(err)
+		return _responses.InternalServerError("Failed to read SetUserQuota parameters")
+	}
+
+	db := database.GetInstance().UserStats.Prepare(rctx)
+
+	for userId, quota := range params {
+		if quota.MaxBytes < -1 || quota.MaxFiles < -1 || quota.MaxPending < -1 {
+			rctx.Log.Warn("SetUserQuota parameters for user " + userId + " must be >= -1. Skipping...")
+			continue
+		}
+
+		err = db.SetUserQuota(userId, quota.MaxBytes, quota.MaxFiles, quota.MaxPending)
+		if err != nil {
+			rctx.Log.Error(err)
+			sentry.CaptureException(err)
+			return _responses.InternalServerError("Failed to set quota for user " + userId)
+		}
+	}
+
+	return &_responses.DoNotCacheResponse{Payload: &_responses.EmptyResponse{}}
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -97,6 +97,8 @@ func buildRoutes() http.Handler {
 		{":taskId", makeRoute(_routers.RequireRepoAdmin(custom.GetTask), "get_background_task", counter)},
 	})
 	register([]string{"GET"}, PrefixMedia, "admin/tasks/*branch", mxUnstable, router, tasksBranch)
+	register([]string{"GET"}, PrefixMedia, "admin/users/quota", mxUnstable, router, makeRoute(_routers.RequireRepoAdmin(custom.GetUserQuota), "get_user_quota", counter))
+	register([]string{"PUT"}, PrefixMedia, "admin/users/quota", mxUnstable, router, makeRoute(_routers.RequireRepoAdmin(custom.SetUserQuota), "set_user_quota", counter))
 	register([]string{"POST"}, PrefixMedia, "admin/user/:userId/export", mxUnstable, router, makeRoute(_routers.RequireAccessToken(custom.ExportUserData), "export_user_data", counter))
 	register([]string{"POST"}, PrefixMedia, "admin/server/:serverName/export", mxUnstable, router, makeRoute(_routers.RequireAccessToken(custom.ExportServerData), "export_server_data", counter))
 	register([]string{"GET"}, PrefixMedia, "admin/export/:exportId/view", mxUnstable, router, makeRoute(_routers.OptionalAccessToken(custom.ViewExport), "view_export", counter))

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -271,7 +271,8 @@ uploads:
     # The upload quota rules which affect users. The first rule to match the user ID will take
     # effect. If a user does not match a rule, the defaults implied by the above config will
     # take effect instead. The user will not be permitted to upload anything above these quota
-    # values, but can match them exactly.
+    # values, but can match them exactly. Note that quotas can also be set per-user via the
+    # admin API and will take precedence over any matches listed in the config file.
     users:
       - glob: "@*:*"  # Affect all users. Use asterisks (*) to match any character.
         # The maximum number of TOTAL bytes a user can upload. Defaults to zero (no limit).

--- a/database/table_user_stats.go
+++ b/database/table_user_stats.go
@@ -4,18 +4,35 @@ import (
 	"database/sql"
 	"errors"
 
+	"github.com/lib/pq"
 	"github.com/t2bot/matrix-media-repo/common/rcontext"
 )
+
+type UserQuota struct {
+	MaxBytes   int64
+	MaxPending int64
+	MaxFiles   int64
+}
 
 type DbUserStats struct {
 	UserId        string
 	UploadedBytes int64
+	UserQuota     *UserQuota
+	// UserQuotaMaxBytes   int64
+	// UserQuotaMaxPending int64
+	// UserQuotaMaxFiles   int64
 }
 
 const selectUserStatsUploadedBytes = "SELECT uploaded_bytes FROM user_stats WHERE user_id = $1;"
+const selectUserQuota = "SELECT user_id, uploaded_bytes, quota_max_bytes, quota_max_pending, quota_max_files FROM user_stats WHERE user_id = ANY($1);"
+const updateUserQuota = "UPDATE user_stats SET quota_max_bytes = $2, quota_max_pending = $3, quota_max_files = $4 WHERE user_id = $1;"
+const insertUserQuota = "INSERT INTO user_stats (user_id, uploaded_bytes, quota_max_bytes, quota_max_pending, quota_max_files) VALUES ($1, $2, $3, $4, $5);"
 
 type userStatsTableStatements struct {
 	selectUserStatsUploadedBytes *sql.Stmt
+	selectUserQuota              *sql.Stmt
+	updateUserQuota              *sql.Stmt
+	insertUserQuota              *sql.Stmt
 }
 
 type userStatsTableWithContext struct {
@@ -29,6 +46,15 @@ func prepareUserStatsTables(db *sql.DB) (*userStatsTableStatements, error) {
 
 	if stmts.selectUserStatsUploadedBytes, err = db.Prepare(selectUserStatsUploadedBytes); err != nil {
 		return nil, errors.New("error preparing selectUserStatsUploadedBytes: " + err.Error())
+	}
+	if stmts.selectUserQuota, err = db.Prepare(selectUserQuota); err != nil {
+		return nil, errors.New("error preparing selectUserQuota: " + err.Error())
+	}
+	if stmts.updateUserQuota, err = db.Prepare(updateUserQuota); err != nil {
+		return nil, errors.New("error preparing updateUserQuota: " + err.Error())
+	}
+	if stmts.insertUserQuota, err = db.Prepare(insertUserQuota); err != nil {
+		return nil, errors.New("error preparing insertUserQuota: " + err.Error())
 	}
 
 	return stmts, nil
@@ -50,4 +76,40 @@ func (s *userStatsTableWithContext) UserUploadedBytes(userId string) (int64, err
 		val = 0
 	}
 	return val, err
+}
+
+func (s *userStatsTableWithContext) GetUserQuota(userIds []string) ([]*DbUserStats, error) {
+	rows, err := s.statements.selectUserQuota.QueryContext(s.ctx, pq.Array(userIds))
+
+	results := make([]*DbUserStats, 0)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return results, nil
+		}
+		return nil, err
+	}
+	for rows.Next() {
+		val := &DbUserStats{UserQuota: &UserQuota{}}
+		if err = rows.Scan(&val.UserId, &val.UploadedBytes, &val.UserQuota.MaxBytes, &val.UserQuota.MaxPending, &val.UserQuota.MaxFiles); err != nil {
+			return nil, err
+		}
+		results = append(results, val)
+	}
+
+	return results, nil
+}
+
+func (s *userStatsTableWithContext) SetUserQuota(userId string, maxBytes int64, maxPending int64, maxFiles int64) error {
+	// Need to insert default record if user has not uploaded any media beforehand
+	row := s.statements.selectUserQuota.QueryRowContext(s.ctx, pq.Array([]string{userId}))
+	val := &DbUserStats{UserQuota: &UserQuota{}}
+	err := row.Scan(&val.UserId, &val.UploadedBytes, &val.UserQuota.MaxBytes, &val.UserQuota.MaxPending, &val.UserQuota.MaxFiles)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		_, err = s.statements.insertUserQuota.ExecContext(s.ctx, userId, 0, maxBytes, maxFiles, maxPending)
+	} else {
+		_, err = s.statements.updateUserQuota.ExecContext(s.ctx, userId, maxBytes, maxFiles, maxPending)
+	}
+
+	return err
 }

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -313,6 +313,8 @@ Only repository administrators can use these endpoints.
 
 URL: `GET /_matrix/media/unstable/admin/users/quota?access_token=your_access_token`
 
+This endpoint queries the database for per-user quota entries set via the admin API. It will NOT retrieve the user's quota values if there is a glob entry in the config file that matches the user id. To query the quota values that currently take effect for the given user, you must use the media limits `/config` endpoint as specified in https://github.com/matrix-org/matrix-spec-proposals/pull/4034
+
 You may specify one or more `?user_id=@alice:example.org` query parameters. Note that encoding the values may be required (not shown here). Users that are unknown to the media repo will not be returned.
 
 The response for querying a user's quota:

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -112,13 +112,13 @@ Note that this will only quarantine what is currently known to the repo. It will
 
 ## Datastore management
 
-Datastores are used by the media repository to put files. Typically these match what is configured in the config file, such as s3 and directories. 
+Datastores are used by the media repository to put files. Typically these match what is configured in the config file, such as s3 and directories.
 
 #### Listing available datastores
 
 URL: `GET /_matrix/media/unstable/admin/datastores?access_token=your_access_token`
 
-The result will be something like: 
+The result will be something like:
 ```json
 {
   "00be9363007feb66de554a79e16b7b49": {
@@ -300,6 +300,48 @@ The response is how much data the server is using:
 Use the same endpoint as above, but specifying one or more `?mxc=mxc://example.org/abc123` query parameters. Note that encoding the values may be required (not shown here).
 
 Only repository administrators can use these endpoints.
+
+## User quotas
+
+In addition to specifying quotas in the config file, you may also set per-user quota entries via the admin API. Any value set via the API will take precedence over any matches to the user specified in the config file. To unset any user's quota values, you must set the entry to '-1'. To set a user's quota values using the default limits, set the entries to '0'.
+
+Note that quotas must be enabled in the config in order for any quota values set via the admin API to take effect.
+
+Only repository administrators can use these endpoints.
+
+#### Get user quotas
+
+URL: `GET /_matrix/media/unstable/admin/users/quota?access_token=your_access_token`
+
+You may specify one or more `?user_id=@alice:example.org` query parameters. Note that encoding the values may be required (not shown here). Users that are unknown to the media repo will not be returned.
+
+The response for querying a user's quota:
+```json
+{
+  "@alice:example.org": {
+      "max_bytes": 53687063712,
+      "max_pending": -1,
+      "max_files": 100
+    }
+}
+```
+
+#### Set user quotas
+
+URL: `PUT /_matrix/media/unstable/admin/users/quota?access_token=your_access_token`
+
+You may specify one or more user ids in the json body. Note that encoding the values may be required (not shown here). Also, you may set the quota value for a user even if the user entry does not already exist.
+
+The example json body for setting a user's quota:
+```json
+{
+  "@alice:example.org": {
+      "max_bytes": 53687063712,
+      "max_pending": -1,
+      "max_files": 100
+    }
+}
+```
 
 ## Background Tasks API
 
@@ -494,9 +536,9 @@ URL: `POST /_matrix/media/unstable/admin/import`
 
 The request body is the bytes of the first archive (eg: `TravisR-part-1.tgz` in the above examples).
 
-The response body will be something like the following: 
+The response body will be something like the following:
 ```json
-{ 
+{
   "import_id": "abcdef",
   "task_id": 13
 }

--- a/migrations/29_add_user_stats_quotas_down.sql
+++ b/migrations/29_add_user_stats_quotas_down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE user_stats DROP COLUMN quota_max_bytes;
+ALTER TABLE user_stats DROP COLUMN quota_max_pending;
+ALTER TABLE user_stats DROP COLUMN quota_max_files;

--- a/migrations/29_add_user_stats_quotas_up.sql
+++ b/migrations/29_add_user_stats_quotas_up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE user_stats ADD COLUMN quota_max_bytes BIGINT NOT NULL DEFAULT '-1';
+ALTER TABLE user_stats ADD COLUMN quota_max_pending BIGINT NOT NULL DEFAULT '-1';
+ALTER TABLE user_stats ADD COLUMN quota_max_files BIGINT NOT NULL DEFAULT '-1';


### PR DESCRIPTION
We currently have the ability to set quotas for users in the config file via matching glob patterns. This works well primarily in the case for setting per-domain quotas for users rather than specific users. Although we can set glob entries that match specific users, it does not scale well when having to specify quota values for lots of users. Additionally, repo admins who do not have access to the config file cannot programmatically set user quotas. 

To address these current quota limitations, I've added support via the admin API the ability to get and set per-user quotas in the MMR database.  By default, the config quota globs take precedence unless a user's quota values are specifically set via the admin API.

See admin API docs for further details regarding endpoints added.