### PR TITLE
Add support for batch record purging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * New datastore option to ignore Redis cache when downloading media served by a `publicBaseUrl`. This can help ensure more requests get redirected to the CDN.
 * `HEAD /download` is now supported, as per [MSC4120](https://github.com/matrix-org/matrix-spec-proposals/pull/4120).
+* The `POST /_matrix/media/unstable/admin/purge/<server>/<media id>` endpoint now supports batch purging of media ids.
 
 ### Fixed
 
@@ -109,13 +110,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * IPFS support has been removed due to maintenance burden.
 * Exports initiated through the admin API no longer support `?include_data=false`. Exports will always contain data.
-* Server-side blurhash calculation has been removed. Clients and bridges already calculate blurhashes locally where applicable. 
+* Server-side blurhash calculation has been removed. Clients and bridges already calculate blurhashes locally where applicable.
 
 ### Changed
 
 * **Mandatory configuration change**: You must add datastore IDs to your datastore configuration, as matrix-media-repo will no longer manage datastores for you.
 * If compiling `matrix-media-repo`, note that new external dependencies are required. See [the docs](https://docs.t2bot.io/matrix-media-repo/v1.3.3/installing/method/compilation.html).
-  * Docker images already contain these dependencies. 
+  * Docker images already contain these dependencies.
 * Datastores no longer use the `enabled` flag set on them. Use `forKinds: []` instead to disable a datastore's usage.
 * Per-user upload quotas now do not allow users to exceed the maximum values, even by 1 byte. Previously, users could exceed the limits by a little bit.
 * Updated to Go 1.19, then Go 1.20 in the same release cycle.
@@ -355,7 +356,7 @@ a large database (more than about 100k uploaded files), run the following steps 
    user is `media`, then run:
    ```sql
    ALTER TABLE user_stats OWNER TO media;
-   ALTER FUNCTION track_update_user_media() OWNER TO media; 
+   ALTER FUNCTION track_update_user_media() OWNER TO media;
    ```
 
 ### Added

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -44,13 +44,15 @@ URL: `POST /_matrix/media/unstable/admin/purge/quarantined?access_token=your_acc
 
 This will delete all media that has previously been quarantined, local or remote. If called by a homeserver administrator (who is not a repository administrator), only content quarantined for their domain will be purged.
 
-#### Purge individual record
+#### Purge individual record (batch of records / single record)
 
 URL: `POST /_matrix/media/unstable/admin/purge/<server>/<media id>?access_token=your_access_token`
 
 **Note**: Prior to v1.3, this endpoint did not require the `/media` component, but does now.
 
 This will delete the media record, regardless of it being local or remote. Can be called by homeserver administrators and the uploader to delete it.
+
+For a batch of records, use the same endpoint as above, but specifying one or more `?id=<media id>` query parameters.
 
 #### Purge media uploaded by user
 

--- a/tasks/task_runner/purge.go
+++ b/tasks/task_runner/purge.go
@@ -30,10 +30,16 @@ func (c *PurgeAuthContext) canAffect(media *database.DbMedia) bool {
 	return true
 }
 
-func PurgeMedia(ctx rcontext.RequestContext, authContext *PurgeAuthContext, toHandle *QuarantineThis) ([]string, error) {
-	records, err := resolveMedia(ctx, "", toHandle)
-	if err != nil {
-		return nil, err
+func PurgeMedia(ctx rcontext.RequestContext, authContext *PurgeAuthContext, toHandles []*QuarantineThis) ([]string, error) {
+	records := make([]*database.DbMedia, 0)
+
+	for _, toHandle := range toHandles {
+		record, err := resolveMedia(ctx, "", toHandle)
+		if err != nil {
+			return nil, err
+		}
+
+		records = append(records, record...)
 	}
 
 	// Check auth on all records before actually processing them


### PR DESCRIPTION
Our application has the need to purge batches records, and I wanted to share these changes in case they are of interest to the upstream project. Similar to the `/admin/usage/<server name>/users` endpoint, I've added the ability to specify multiple `?id=<media id>` fields to the `POST /_matrix/media/unstable/admin/purge/<server>/<media id>` endpoint for batch record purging.