### PR TITLE
Fix directory permissions in import_to_synapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Long-running purge requests no longer fail when the requesting client times out. They are continued in the background.
 * Purging old media has been fixed to actually identify old media.
 * JPEG thumbnails will now use sensible extensions.
+* Fixed directory permissions when exporting MMR to Synapse.
 
 ## [1.3.4] - February 9, 2024
 

--- a/cmd/homeserver_offline_exporters/import_to_synapse/main.go
+++ b/cmd/homeserver_offline_exporters/import_to_synapse/main.go
@@ -78,7 +78,7 @@ func main() {
 
 		ctx.Log.Infof("Copying %s", mxc)
 		directories := path.Join(cfg.ExportPath, "local_content", record.MediaId[0:2], record.MediaId[2:4])
-		err = os.MkdirAll(directories, 0655)
+		err = os.MkdirAll(directories, 0755)
 		if err != nil {
 			return err
 		}
@@ -134,7 +134,7 @@ func main() {
 				dirLock.Lock()
 				defer dirLock.Unlock()
 				thumbDir := path.Join(cfg.ExportPath, "local_thumbnails", record.MediaId[0:2], record.MediaId[2:4], record.MediaId[4:])
-				err = os.MkdirAll(thumbDir, 0655)
+				err = os.MkdirAll(thumbDir, 0755)
 				if err != nil {
 					ctx.Log.Warn("Error creating thumbnail directories. ", s, err)
 					return


### PR DESCRIPTION
The directory permissions 0655 map to rw-r-x-rx, which excludes the owner from accessing created directories, which the creation of directories in the media store.

Tested while migrating the nixos.org homeserver away from EMS.