### PR TITLE
Return a 404 instead of 500 when clients access media which is frozen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-*Nothing yet*
+### Fixed
+
+* Return a 404 instead of 500 when clients access media which is frozen.
 
 ## [1.3.7] - July 30, 2024
 

--- a/api/r0/download.go
+++ b/api/r0/download.go
@@ -96,7 +96,7 @@ func DownloadMedia(r *http.Request, rctx rcontext.RequestContext, auth _apimeta.
 			return _responses.ErrorResponse{
 				Code:         common.ErrCodeNotFound,
 				Message:      "authentication is required to download this media",
-				InternalCode: common.ErrCodeUnauthorized,
+				InternalCode: common.ErrCodeNotFound, // used to determine http status code
 			}
 		} else if errors.Is(err, common.ErrMediaTooLarge) {
 			return _responses.RequestTooLarge()

--- a/api/r0/thumbnail.go
+++ b/api/r0/thumbnail.go
@@ -147,7 +147,7 @@ func ThumbnailMedia(r *http.Request, rctx rcontext.RequestContext, auth _apimeta
 			return _responses.ErrorResponse{
 				Code:         common.ErrCodeNotFound,
 				Message:      "authentication is required to download this media",
-				InternalCode: common.ErrCodeUnauthorized,
+				InternalCode: common.ErrCodeNotFound, // used to determine http status code
 			}
 		} else if errors.Is(err, common.ErrMediaTooLarge) {
 			return _responses.RequestTooLarge()


### PR DESCRIPTION
Fixes https://github.com/t2bot/matrix-media-repo/issues/603