### PR TITLE
Fix local development docker compose nginx config to work properly with non-docker-for-desktop setups

### DIFF
--- a/dev/homeserver.nginx.conf
+++ b/dev/homeserver.nginx.conf
@@ -6,17 +6,23 @@ server {
 
     location /_matrix/media {
       proxy_set_header Host localhost;
-      proxy_pass http://host.docker.internal:8001;
+      resolver 127.0.0.11 valid=10s;
+      set $target http://host.docker.internal:8001;
+      proxy_pass $target$request_uri;
     }
 
     location /_matrix/client/v1/media {
       proxy_set_header Host localhost;
-      proxy_pass http://host.docker.internal:8001;
+      resolver 127.0.0.11 valid=10s;
+      set $target http://host.docker.internal:8001;
+      proxy_pass $target$request_uri;
     }
 
     location /_matrix/federation/v1/media {
       proxy_set_header Host localhost;
-      proxy_pass http://host.docker.internal:8001;
+      resolver 127.0.0.11 valid=10s;
+      set $target http://host.docker.internal:8001;
+      proxy_pass $target$request_uri;
     }
 
     location /_matrix {


### PR DESCRIPTION
With most non-docker-for-desktop docker setups (for example native docker on linux) the host.docker.internal domain is not properly resolved at nginx startup. The typical "fix" is to instruct nginx explicitly to use the docker embedded dns resolver at 127.0.0.11 dynamically at request time by specifying the resolver in the config as well as putting the actual target for the proxy_pass directive behind a variable (otherwise nginx will attempt to resolve the address at startup and never again after that)