### PR TITLE
Add option to presign public S3 URL

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -224,6 +224,13 @@ datastores:
       # capability. MMR may still be responsible for bandwidth charges incurred from going to
       # the bucket directly.
       #publicBaseUrl: "https://mycdn.example.org/"
+      # When set, the public S3 URL will be presigned before redirection. This allows users
+      # to directly download from private S3 buckets as long as the URL is still valid.
+      #presignUrl: false
+      # The time in seconds that a presigned URL will be valid for before expiring.
+      # This value must be between 60 (1 minute) and 604800 (7 days). Ensure it is high
+      # enough that users with slow connections will be able to download the media before it expires.
+      #presignExpiry: 86400
       # Set to `true` to bypass any local cache when `publicBaseUrl` is set. Has no effect
       # when `publicBaseUrl` is unset. Defaults to false (cached media will be served by MMR
       # before redirection if present).

--- a/datastores/s3.go
+++ b/datastores/s3.go
@@ -21,6 +21,8 @@ type s3 struct {
 	storageClass       string
 	bucket             string
 	publicBaseUrl      string
+	presignUrl         bool
+	presignExpiry      int
 	redirectWhenCached bool
 	prefixLength       int
 	multipartUploads   bool
@@ -43,6 +45,8 @@ func getS3(ds config.DatastoreConfig) (*s3, error) {
 	storageClass, hasStorageClass := ds.Options["storageClass"]
 	useSslStr, hasSsl := ds.Options["ssl"]
 	publicBaseUrl := ds.Options["publicBaseUrl"]
+	presignUrlStr, hasPresignUrl := ds.Options["presignUrl"]
+	presignExpiryStr, hasPresignExpiry := ds.Options["presignExpiry"]
 	redirectWhenCachedStr, hasRedirectWhenCached := ds.Options["redirectWhenCached"]
 	prefixLengthStr, hasPrefixLength := ds.Options["prefixLength"]
 	useMultipartStr, hasMultipart := ds.Options["multipartUploads"]
@@ -59,6 +63,22 @@ func getS3(ds config.DatastoreConfig) (*s3, error) {
 	useMultipart := true
 	if hasMultipart && useMultipartStr != "" {
 		useMultipart, _ = strconv.ParseBool(useMultipartStr)
+	}
+
+	presignUrl := false
+	if hasPresignUrl && presignUrlStr != "" {
+		presignUrl, _ = strconv.ParseBool(presignUrlStr)
+	}
+
+	presignExpiry := 86400
+	if hasPresignExpiry && presignExpiryStr != "" {
+		presignExpiry, _ = strconv.Atoi(presignExpiryStr)
+		if presignExpiry < 60 {
+			presignExpiry = 60
+		}
+		if presignExpiry > 604800 {
+			presignExpiry = 604800
+		}
 	}
 
 	redirectWhenCached := false
@@ -93,6 +113,8 @@ func getS3(ds config.DatastoreConfig) (*s3, error) {
 		storageClass:       storageClass,
 		bucket:             bucket,
 		publicBaseUrl:      publicBaseUrl,
+		presignUrl:         presignUrl,
+		presignExpiry:      presignExpiry,
 		redirectWhenCached: redirectWhenCached,
 		prefixLength:       prefixLength,
 		multipartUploads:   useMultipart,


### PR DESCRIPTION
This adds support for presigning public S3 URLs so that you can use the S3 redirect feature without having to make the entire bucket public. The expiry time is also configurable, between 1 minute (min for Amazon S3 I think?) and 7 days (max S3 value).