### PR TITLE
Add rate limit config enabled check to download pipelines

### DIFF
--- a/limits/leaky_buckets.go
+++ b/limits/leaky_buckets.go
@@ -13,10 +13,6 @@ var buckets = make(map[string]*leaky.Bucket)
 var bucketLock = &sync.Mutex{}
 
 func GetBucket(ctx rcontext.RequestContext, subject string) (*leaky.Bucket, error) {
-	if !config.Get().RateLimit.Enabled {
-		return nil, nil
-	}
-
 	bucketLock.Lock()
 	defer bucketLock.Unlock()
 

--- a/pipelines/pipeline_download/pipeline.go
+++ b/pipelines/pipeline_download/pipeline.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/t2bot/go-leaky-bucket"
-	"github.com/t2bot/go-singleflight-streams"
+	sfstreams "github.com/t2bot/go-singleflight-streams"
 	"github.com/t2bot/matrix-media-repo/common"
+	"github.com/t2bot/matrix-media-repo/common/config"
 	"github.com/t2bot/matrix-media-repo/common/rcontext"
 	"github.com/t2bot/matrix-media-repo/database"
 	"github.com/t2bot/matrix-media-repo/limits"
@@ -76,11 +77,15 @@ func Execute(ctx rcontext.RequestContext, origin string, mediaId string, opts Do
 	}
 
 	// Check rate limits before moving on much further
-	limitBucket, err := limits.GetBucket(ctx, limits.GetRequestIP(ctx.Request))
-	if err != nil {
-		cancel()
-		return nil, nil, err
+	var limitBucket *leaky.Bucket = nil
+	if config.Get().RateLimit.Enabled {
+		limitBucket, err = limits.GetBucket(ctx, limits.GetRequestIP(ctx.Request))
+		if err != nil {
+			cancel()
+			return nil, nil, err
+		}
 	}
+
 	didBucketMaxSize := false
 	if limitBucket != nil {
 		if record == nil {

--- a/pipelines/pipeline_thumbnail/pipeline.go
+++ b/pipelines/pipeline_thumbnail/pipeline.go
@@ -10,6 +10,7 @@ import (
 	"github.com/t2bot/go-leaky-bucket"
 	sfstreams "github.com/t2bot/go-singleflight-streams"
 	"github.com/t2bot/matrix-media-repo/common"
+	"github.com/t2bot/matrix-media-repo/common/config"
 	"github.com/t2bot/matrix-media-repo/common/rcontext"
 	"github.com/t2bot/matrix-media-repo/database"
 	"github.com/t2bot/matrix-media-repo/limits"
@@ -87,11 +88,15 @@ func Execute(ctx rcontext.RequestContext, origin string, mediaId string, opts Th
 	}
 
 	// Check rate limits before moving on much further
-	limitBucket, err := limits.GetBucket(ctx, limits.GetRequestIP(ctx.Request))
-	if err != nil {
-		cancel()
-		return nil, nil, err
+	var limitBucket *leaky.Bucket = nil
+	if config.Get().RateLimit.Enabled {
+		limitBucket, err = limits.GetBucket(ctx, limits.GetRequestIP(ctx.Request))
+		if err != nil {
+			cancel()
+			return nil, nil, err
+		}
 	}
+
 	if limitBucket != nil && record != nil && !opts.RecordOnly {
 		if limitErr := limitBucket.Add(record.SizeBytes); limitErr != nil {
 			cancel()


### PR DESCRIPTION
Previously we checked for rate limits being enabled in the `limits.GetBucket` function. However the pipelines also call other limits code, like `limits.GetRequestIP`, that seems to fail in some situations, for example when running `gdpr_export`.

Move the rate limits config check to a higher level before calling either of these limits functions which allows using `gdpr_export` with rate limits disabled.

Does not directly fix https://github.com/t2bot/matrix-media-repo/issues/637 but allows working around it.