### PR TITLE
feat(redis): support Redis authentication password in config and connections

### DIFF
--- a/common/config/models_main.go
+++ b/common/config/models_main.go
@@ -96,9 +96,10 @@ type SentryConfig struct {
 }
 
 type RedisConfig struct {
-	Enabled bool               `yaml:"enabled"`
-	Shards  []RedisShardConfig `yaml:"shards,flow"`
-	DbNum   int                `default:"0" yaml:"databaseNumber"`
+	Enabled  bool               `yaml:"enabled"`
+	Shards   []RedisShardConfig `yaml:"shards,flow"`
+	DbNum    int                `default:"0" yaml:"databaseNumber"`
+	Password string             `yaml:"password"`
 }
 
 type RedisShardConfig struct {

--- a/common/config/watch.go
+++ b/common/config/watch.go
@@ -100,7 +100,8 @@ func onFileChanged() {
 
 	redisEnabledChange := configNew.Redis.Enabled != configNow.Redis.Enabled
 	redisShardsChange := hasRedisShardConfigChanged(configNew, configNow)
-	if redisEnabledChange || redisShardsChange {
+	redisPasswordChange := configNew.Redis.Password != configNow.Redis.Password
+	if redisEnabledChange || redisShardsChange || redisPasswordChange {
 		logrus.Warn("Cache configuration changed - reloading")
 		globals.CacheReplaceChan <- true
 	}

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -405,7 +405,7 @@ urlPreviews:
     - 'fc00::/7'
   allowedNetworks:
     - "0.0.0.0/0" # "Everything". The deny list will help limit this.
-                  # This is the default value for this field.
+    # This is the default value for this field.
 
   # How many days after a preview is generated before it expires and is deleted. The preview
   # can be regenerated safely - this just helps free up some space in your database. Set to
@@ -640,7 +640,7 @@ plugins:
 # Sections of this config might disappear or be added over time. By default all
 # features are disabled in here and must be explicitly enabled to be used.
 featureSupport:
-  # No unstable features are currently supported.
+# No unstable features are currently supported.
 
 # Support for redis as a cache mechanism
 #
@@ -654,6 +654,10 @@ redis:
 
   # The database number to use. Leave at zero if using a dedicated Redis instance.
   databaseNumber: 0
+
+  # Optional password for Redis authentication. Leave empty if your Redis instance
+  # does not require authentication. This password applies to all shards and the ring.
+  password: ""
 
   # The Redis shards that should be used by the media repo in the ring. The names of the
   # shards are for your reference and have no bearing on the connection, but must be unique.

--- a/redislib/connection.go
+++ b/redislib/connection.go
@@ -35,6 +35,7 @@ func makeConnection() {
 				DialTimeout: 10 * time.Second,
 				DB:          conf.DbNum,
 				Addr:        c.Address,
+				Password:    conf.Password,
 			})
 			clients = append(clients, client)
 			pools = append(pools, goredis.NewPool(client))
@@ -43,6 +44,7 @@ func makeConnection() {
 			Addrs:       addresses,
 			DialTimeout: 10 * time.Second,
 			DB:          conf.DbNum,
+			Password:    conf.Password,
 		})
 		rs = redsync.New(pools...)
 	})


### PR DESCRIPTION
- add `redis.password` to config model and sample config
- pass password to Redis client and ring connection options
- trigger cache reload when Redis password changes